### PR TITLE
Have Ren'Py put all AliceOS files into its own RPA

### DIFF
--- a/game/options.rpy
+++ b/game/options.rpy
@@ -145,6 +145,7 @@ init python:
     build.archive("scripts",build.name)
     build.archive("mod_assets",build.name)
     build.archive("submods",build.name)
+    build.archive("aliceos",build.name)
 
     # folder / files to put in archives
     build.classify("game/mod_assets/**","mod_assets")
@@ -152,6 +153,13 @@ init python:
     build.classify('game/**.rpyc',"scripts")
     build.classify('game/advanced_scripts/**',"scripts")
     build.classify('game/original_story_scripts/**',"scripts")
+
+    # AliceOS-related files
+    build.classify("game/Applets/**", "aliceos")
+    build.classify("game/CoreServices/**", "aliceos")
+    build.classify("game/Frameworks/**", "aliceos")
+    build.classify("game/Resources/**", "aliceos")
+    build.classify("game/gui/**", "aliceos")
 
     # stuff to ignore
     build.classify('**~', None)


### PR DESCRIPTION
Code copied over from The Angel Returns. Fixes error where AliceOS are rendered missing due to a packaging error.